### PR TITLE
Port 4.13 canonicaly functionality

### DIFF
--- a/src/DependencyInjection/Compiler/AdjustContainerPass.php
+++ b/src/DependencyInjection/Compiler/AdjustContainerPass.php
@@ -1,23 +1,31 @@
 <?php
 
-/*
- * Copyright (c) 2020 Heimrich & Hannot GmbH
- *
- * @license LGPL-3.0-or-later
- */
-
 namespace HeimrichHannot\HeadBundle\DependencyInjection\Compiler;
 
+use Contao\CoreBundle\EventListener\DataContainer\DisableCanonicalFieldsListener;
+use HeimrichHannot\HeadBundle\EventListener\CanonicalListener;
 use HeimrichHannot\HeadBundle\Head\TagInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class HeadServicePass implements CompilerPassInterface
+class AdjustContainerPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritdoc}
-     */
+
     public function process(ContainerBuilder $container)
+    {
+        if (class_exists(DisableCanonicalFieldsListener::class)) {
+            $container->removeDefinition(CanonicalListener::class);
+        }
+
+        $this->processLegacy($container);
+    }
+
+    /**
+     * @todo remove in next major version
+     *
+     * @noinspection PhpDeprecationInspection
+     */
+    protected function processLegacy(ContainerBuilder $container)
     {
         $tags = [];
         $definitions = $container->getDefinitions();

--- a/src/DependencyInjection/HeimrichHannotHeadBundleExtension.php
+++ b/src/DependencyInjection/HeimrichHannotHeadBundleExtension.php
@@ -1,13 +1,15 @@
 <?php
 
 /*
- * Copyright (c) 2022 Heimrich & Hannot GmbH
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
  *
  * @license LGPL-3.0-or-later
  */
 
 namespace HeimrichHannot\HeadBundle\DependencyInjection;
 
+use Contao\CoreBundle\EventListener\DataContainer\DisableCanonicalFieldsListener;
+use HeimrichHannot\HeadBundle\EventListener\CanonicalListener;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 
@@ -18,6 +20,10 @@ class HeimrichHannotHeadBundleExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
         $container->setParameter('huh_head', $config);
+
+        if (class_exists(DisableCanonicalFieldsListener::class)) {
+            $container->removeDefinition(CanonicalListener::class);
+        }
     }
 
     public function getAlias()

--- a/src/DependencyInjection/HeimrichHannotHeadBundleExtension.php
+++ b/src/DependencyInjection/HeimrichHannotHeadBundleExtension.php
@@ -8,8 +8,6 @@
 
 namespace HeimrichHannot\HeadBundle\DependencyInjection;
 
-use Contao\CoreBundle\EventListener\DataContainer\DisableCanonicalFieldsListener;
-use HeimrichHannot\HeadBundle\EventListener\CanonicalListener;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 
@@ -20,10 +18,6 @@ class HeimrichHannotHeadBundleExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
         $container->setParameter('huh_head', $config);
-
-        if (class_exists(DisableCanonicalFieldsListener::class)) {
-            $container->removeDefinition(CanonicalListener::class);
-        }
     }
 
     public function getAlias()

--- a/src/EventListener/CanonicalListener.php
+++ b/src/EventListener/CanonicalListener.php
@@ -48,11 +48,6 @@ class CanonicalListener
 
         $dca = &$GLOBALS['TL_DCA'][$table];
 
-        // check if field already exists (since this is core function in since contao 4.13)
-        if (isset($dca['fields']['enableCanonical'])) {
-            return;
-        }
-
         $dca['fields']['enableCanonical'] = [
             'exclude' => true,
             'inputType' => 'checkbox',
@@ -96,7 +91,7 @@ class CanonicalListener
             return $value;
         }
 
-        if (($rootPageModel = $this->utils->request()->getCurrentRootPageModel()) === null) {
+        if (($rootPageModel = $this->utils->request()->getCurrentRootPageModel($pageModel)) === null) {
             return $value;
         }
 

--- a/src/EventListener/CanonicalListener.php
+++ b/src/EventListener/CanonicalListener.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\HeadBundle\EventListener;
+
+use Contao\Controller;
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\CoreBundle\ServiceAnnotation\Hook;
+use Contao\DataContainer;
+use Contao\LayoutModel;
+use Contao\PageModel;
+use Contao\PageRegular;
+use HeimrichHannot\HeadBundle\Manager\HtmlHeadTagManager;
+use HeimrichHannot\UtilsBundle\Util\Utils;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Backports canonical link functionality of contao 4.13 to contao 4.9.
+ */
+class CanonicalListener
+{
+    private Utils $utils;
+    private HtmlHeadTagManager $headTagManager;
+    private RequestStack $requestStack;
+
+    public function __construct(Utils $utils, HtmlHeadTagManager $headTagManager, RequestStack $requestStack)
+    {
+        $this->utils = $utils;
+        $this->headTagManager = $headTagManager;
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * @Hook("loadDataContainer")
+     */
+    public function addFields(string $table): void
+    {
+        if (PageModel::getTable() !== $table) {
+            return;
+        }
+
+        $dca = &$GLOBALS['TL_DCA'][$table];
+
+        // check if field already exists (since this is core function in since contao 4.13)
+        if (isset($dca['fields']['enableCanonical'])) {
+            return;
+        }
+
+        $dca['fields']['enableCanonical'] = [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'default' => true,
+            'eval' => ['tl_class' => 'w50 m12'],
+            'sql' => "char(1) NOT NULL default ''",
+        ];
+        $dca['fields']['canonicalLink'] = [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['rgxp' => 'url', 'decodeEntities' => true, 'maxlength' => 255, 'dcaPicker' => true, 'tl_class' => 'w50'],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ];
+        $dca['fields']['canonicalKeepParams'] = [
+            'exclude' => true,
+            'inputType' => 'text',
+            'eval' => ['decodeEntities' => true, 'maxlength' => 255, 'tl_class' => 'w50'],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ];
+
+        PaletteManipulator::create()
+            ->addLegend('canonical_legend', 'meta_legend', PaletteManipulator::POSITION_AFTER, true)
+            ->addField('canonicalLink', 'canonical_legend', PaletteManipulator::POSITION_APPEND)
+            ->addField('canonicalKeepParams', 'canonical_legend', PaletteManipulator::POSITION_APPEND)
+            ->applyToPalette('regular', 'tl_page');
+
+        PaletteManipulator::create()
+            ->addField('enableCanonical', 'adminEmail', PaletteManipulator::POSITION_BEFORE)
+            ->applyToPalette('root', 'tl_page')
+            ->applyToPalette('rootfallback', 'tl_page');
+    }
+
+    /**
+     * @Callback(table="tl_page", target="fields.canonicalLink.load")
+     * @Callback(table="tl_page", target="fields.canonicalKeepParams.load")
+     */
+    public function disableCanonicalFieldsListener(string $value, DataContainer $dc): string
+    {
+        if (!$dc->id || ($pageModel = PageModel::findByPk($dc->id)) === null) {
+            return $value;
+        }
+
+        if (($rootPageModel = $this->utils->request()->getCurrentRootPageModel()) === null) {
+            return $value;
+        }
+
+        if (!$rootPageModel->enableCanonical) {
+            $GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['disabled'] = true;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @Hook("generatePage", priority=-9)
+     */
+    public function addCanonicalIfNotSet(PageModel $pageModel, LayoutModel $layout, PageRegular $pageRegular): void
+    {
+        $rootPageModel = $this->utils->request()->getCurrentRootPageModel($pageModel);
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request || !$rootPageModel->enableCanonical || $this->headTagManager->getCanonical()) {
+            return;
+        }
+
+        if ($pageModel->canonicalLink) {
+            $url = Controller::replaceInsertTags($pageModel->canonicalLink);
+
+            $mainRequest = null;
+
+            if (method_exists($this->requestStack, 'getMainRequest')) {
+                $mainRequest = $this->requestStack->getMainRequest();
+            } else {
+                $mainRequest = $this->requestStack->getMasterRequest();
+            }
+
+            // Ensure absolute links
+            if (!preg_match('#^https?://#', $url)) {
+                if (!$mainRequest) {
+                    throw new \RuntimeException('The request stack did not contain a request');
+                }
+
+                $url = $request->getSchemeAndHttpHost().$request->getBasePath().'/'.$url;
+            }
+
+            $this->headTagManager->setCanonical($url);
+
+            return;
+        }
+
+        $keepParams = [];
+
+        if ($pageModel->canonicalKeepParams) {
+            $keepParams = array_map('trim', explode(',', $pageModel->canonicalKeepParams));
+        }
+
+        $params = [];
+
+        foreach ($request->query->all() as $originalParam => $value) {
+            foreach ($keepParams as $param) {
+                $regex = sprintf('/^%s$/', str_replace('\*', '.*', preg_quote($param, '/')));
+
+                if (preg_match($regex, $originalParam)) {
+                    $params[$originalParam] = $value;
+                }
+            }
+        }
+
+        $request = Request::create(
+            $request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo(),
+            $request->getMethod(),
+            $params
+        );
+
+        $this->headTagManager->setCanonical($request->getUri());
+    }
+}

--- a/src/HeadTag/Link/CanonicalLink.php
+++ b/src/HeadTag/Link/CanonicalLink.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\HeadBundle\HeadTag\Link;
+
+use HeimrichHannot\HeadBundle\HeadTag\LinkTag;
+
+class CanonicalLink extends LinkTag
+{
+    const TYPE = 'canonical';
+    const LEGACY_NAME = 'huh.head.tag.link.canonical';
+
+    public function __construct(string $href)
+    {
+        parent::__construct(self::TYPE, self::TYPE, $href);
+    }
+}

--- a/src/HeadTag/LinkTag.php
+++ b/src/HeadTag/LinkTag.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\HeadBundle\HeadTag;
+
+class LinkTag extends AbstractHeadTag
+{
+    private string $name;
+
+    /*
+     * @param string $name An internal name of the link tag to identify it. Will not be used in the resulting code.
+     */
+    public function __construct(string $name, string $rel, string $href = null)
+    {
+        $this->name = $name;
+        $this->setAttribute('rel', $rel);
+        $this->setAttribute('href', $href);
+    }
+
+    public function generate(): string
+    {
+        return sprintf('<link %s>', $this->generateAttributeString());
+    }
+
+    /**
+     * An internal name of the link tag to identify it. Will not be used in the resulting code.
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * An internal name of the link tag to identify it. Will not be used in the resulting code.
+     */
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/src/HeimrichHannotContaoHeadBundle.php
+++ b/src/HeimrichHannotContaoHeadBundle.php
@@ -1,14 +1,14 @@
 <?php
 
 /*
- * Copyright (c) 2022 Heimrich & Hannot GmbH
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
  *
  * @license LGPL-3.0-or-later
  */
 
 namespace HeimrichHannot\HeadBundle;
 
-use HeimrichHannot\HeadBundle\DependencyInjection\Compiler\HeadServicePass;
+use HeimrichHannot\HeadBundle\DependencyInjection\Compiler\AdjustContainerPass;
 use HeimrichHannot\HeadBundle\DependencyInjection\HeimrichHannotHeadBundleExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -27,7 +27,7 @@ class HeimrichHannotContaoHeadBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new HeadServicePass());
+        $container->addCompilerPass(new AdjustContainerPass());
     }
 
     public function getContainerExtension()

--- a/src/Helper/LegacyHelper.php
+++ b/src/Helper/LegacyHelper.php
@@ -42,9 +42,9 @@ class LegacyHelper
         'huh.head.tag.twitter_player_height' => 'meta_twitter:player:height',
         'huh.head.tag.twitter_player_stream' => 'meta_twitter:player:stream',
         'huh.head.tag.twitter_player_stream_content_type' => 'twitter:player:stream:content_type',
-//        'huh.head.tag.link_prev' => 'link_prev',
-//        'huh.head.tag.link_next' => 'link_next',
-//        'huh.head.tag.link_canonical' => 'link_canonical',
+        'huh.head.tag.link_prev' => 'link_prev',
+        'huh.head.tag.link_next' => 'link_next',
+        'huh.head.tag.link_canonical' => 'link_canonical',
 
         // External bundles
 //        'huh.head.tag.pwa.link_manifest' => 'link_manifest',

--- a/src/Manager/HtmlHeadTagManager.php
+++ b/src/Manager/HtmlHeadTagManager.php
@@ -19,7 +19,6 @@ use HeimrichHannot\HeadBundle\HeadTag\LinkTag;
 use HeimrichHannot\HeadBundle\HeadTag\MetaTag;
 use HeimrichHannot\HeadBundle\HeadTag\TitleTag;
 use HeimrichHannot\HeadBundle\Helper\LegacyHelper;
-use HeimrichHannot\HeadBundle\Helper\TagHelper;
 
 class HtmlHeadTagManager
 {
@@ -30,13 +29,11 @@ class HtmlHeadTagManager
     private array $linkTags = [];
     private HeadTagFactory $headTagFactory;
     private ?TitleTag $titleTag = null;
-    private TagHelper $tagHelper;
 
-    public function __construct(TagManager $legacyTagManager, HeadTagFactory $headTagFactory, TagHelper $tagHelper)
+    public function __construct(TagManager $legacyTagManager, HeadTagFactory $headTagFactory)
     {
         $this->legacyTagManager = $legacyTagManager;
         $this->headTagFactory = $headTagFactory;
-        $this->tagHelper = $tagHelper;
     }
 
     public function getTag(string $name): ?AbstractHeadTag
@@ -237,6 +234,7 @@ class HtmlHeadTagManager
             $buffer .= $linkTag->generate()."\n";
         }
 
+        /* @noinspection PhpDeprecationInspection */
         return $buffer.implode("\n", $this->legacyTagManager->getTags(array_merge(
             array_keys(LegacyHelper::SERVICE_MAP),
             $options['skip_tags']

--- a/src/Manager/HtmlHeadTagManager.php
+++ b/src/Manager/HtmlHeadTagManager.php
@@ -14,6 +14,7 @@ use HeimrichHannot\HeadBundle\Exception\UnsupportedTagException;
 use HeimrichHannot\HeadBundle\HeadTag\AbstractHeadTag;
 use HeimrichHannot\HeadBundle\HeadTag\BaseTag;
 use HeimrichHannot\HeadBundle\HeadTag\HeadTagFactory;
+use HeimrichHannot\HeadBundle\HeadTag\Link\CanonicalLink;
 use HeimrichHannot\HeadBundle\HeadTag\LinkTag;
 use HeimrichHannot\HeadBundle\HeadTag\MetaTag;
 use HeimrichHannot\HeadBundle\HeadTag\TitleTag;
@@ -155,6 +156,32 @@ class HtmlHeadTagManager
         if (isset($this->linkTags[$name])) {
             unset($this->linkTags[$name]);
         }
+    }
+
+    /**
+     * Set canonical url. If null is passed, the canonical tag will be removed. If canonical tag already exists, it will be overwritten.
+     *
+     * @return $this
+     */
+    public function setCanonical(?string $url): self
+    {
+        if (null === $url) {
+            $this->removeLinkTag('canonical');
+
+            return $this;
+        }
+
+        $this->addLinkTag(new CanonicalLink($url));
+
+        return $this;
+    }
+
+    /**
+     * @return LinkTag|CanonicalLink|null
+     */
+    public function getCanonical(): ?LinkTag
+    {
+        return $this->getLinkTag('canonical');
     }
 
     /**

--- a/src/Manager/HtmlHeadTagManager.php
+++ b/src/Manager/HtmlHeadTagManager.php
@@ -307,7 +307,7 @@ class HtmlHeadTagManager
         return $strValue;
     }
 
-    private function addLinkTag(LinkTag $tag)
+    public function addLinkTag(LinkTag $tag)
     {
         $this->linkTags[$tag->getName()] = $tag;
     }

--- a/src/Manager/TagManager.php
+++ b/src/Manager/TagManager.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (c) 2022 Heimrich & Hannot GmbH
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
  *
  * @license LGPL-3.0-or-later
  */
@@ -13,6 +13,9 @@ use Contao\StringUtil;
 use HeimrichHannot\HeadBundle\Head\TagInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * @deprecated Use HeadTagManager instead. Will be removed in next major version.
+ */
 class TagManager
 {
     /**

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -19,4 +19,5 @@ services:
   huh.head.tag_manager:
     class: HeimrichHannot\HeadBundle\Manager\TagManager
     public: true
+    deprecated: ~
   HeimrichHannot\HeadBundle\Manager\TagManager: '@huh.head.tag_manager'

--- a/src/Resources/contao/languages/de/tl_page.php
+++ b/src/Resources/contao/languages/de/tl_page.php
@@ -1,21 +1,32 @@
 <?php
-/**
- * Copyright (c) 2017 Heimrich & Hannot GmbH
- * @author Rico Kaltofen <r.kaltofen@heimrich-hannot.de>
- * @license http://www.gnu.org/licences/lgpl-3.0.html LGPL
+
+/*
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
  */
 
 $lang = &$GLOBALS['TL_LANG']['tl_page'];
 
-/**
+/*
  * Fields
  */
 $lang['addHeadDefaultImage'] = ['Fallback-Bild für die Meta-Tags hinzufügen', 'Dieses Bild wird bspw. für og:image und twitter:image verwendet.'];
 $lang['headDefaultImage'] = ['Fallback-Bild (mind. 200x200)', 'Wählen Sie hier ein Bild aus. Nur PNG- und JPG-Dateien sind erlaubt.'];
 $lang['twitterSite'] = ['Twitter @username', 'Der Twitter @username der einer Twitter-Karte zugewiesen werden soll (twitter:site Attribut).'];
 
-/**
+/*
  * Legends
  */
 $lang['head_legend'] = 'Head-Bundle';
 $lang['head_twitter_legend'] = 'Head-Bundle - Twitter';
+
+if (version_compare(VERSION, '4.13', '<')) {
+    $lang['canonical_legend'] = 'Canonical URL';
+    $lang['enableCanonical'][0] = 'rel=&quot;canonical&quot; aktivieren';
+    $lang['enableCanonical'][1] = 'Der Website rel=&quot;canonical&quot;-Tags hinzufügen.';
+    $lang['canonicalLink'][0] = 'Individuelle URL';
+    $lang['canonicalLink'][1] = 'Hier können Sie eine individuelle kanonische URL wie z. B. https://example.com/ setzen.';
+    $lang['canonicalKeepParams'][0] = 'Query-Parameter';
+    $lang['canonicalKeepParams'][1] = 'Standardmäßig entfernt Contao die Query-Parameter in der kanonischen URL. Hier können Sie eine kommagetrennte Liste von Query-Parametern hinzufügen, die erhalten bleiben sollen. Verwenden Sie &quot;*&quot; als Platzhalter.';
+}

--- a/src/Resources/contao/languages/de/tl_page.php
+++ b/src/Resources/contao/languages/de/tl_page.php
@@ -22,7 +22,7 @@ $lang['head_legend'] = 'Head-Bundle';
 $lang['head_twitter_legend'] = 'Head-Bundle - Twitter';
 
 if (version_compare(VERSION, '4.13', '<')) {
-    $lang['canonical_legend'] = 'Canonical URL';
+    $lang['canonical_legend'] = 'Kanonische URL';
     $lang['enableCanonical'][0] = 'rel=&quot;canonical&quot; aktivieren';
     $lang['enableCanonical'][1] = 'Der Website rel=&quot;canonical&quot;-Tags hinzufügen.';
     $lang['canonicalLink'][0] = 'Individuelle URL';

--- a/src/Resources/contao/languages/en/tl_page.php
+++ b/src/Resources/contao/languages/en/tl_page.php
@@ -1,21 +1,32 @@
 <?php
-/**
- * Copyright (c) 2017 Heimrich & Hannot GmbH
- * @author Rico Kaltofen <r.kaltofen@heimrich-hannot.de>
- * @license http://www.gnu.org/licences/lgpl-3.0.html LGPL
+
+/*
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
  */
 
 $lang = &$GLOBALS['TL_LANG']['tl_page'];
 
-/**
+/*
  * Fields
  */
 $lang['addHeadDefaultImage'] = ['Add fallback image for the meta tags', 'This image is used for og:image and twitter:image.'];
 $lang['headDefaultImage'] = ['Fallback image (at least 200x200)', 'Choose an image here. Only PNG and JPG files allowed.'];
 $lang['twitterSite'] = ['Twitter @username', 'The Twitter @username a twitter card should be attributed to (twitter:site attribute).'];
 
-/**
+/*
  * Legends
  */
 $lang['head_legend'] = 'Head-Bundle';
 $lang['head_twitter_legend'] = 'Head-Bundle - Twitter';
+
+if (version_compare(VERSION, '4.13', '<')) {
+    $lang['canonical_legend'] = 'Canonical URL';
+    $lang['enableCanonical'][0] = 'Enable rel="canonical"';
+    $lang['enableCanonical'][1] = 'Add rel=&quot;canonical&quot; tags to the website.';
+    $lang['canonicalLink'][0] = 'Custom URL';
+    $lang['canonicalLink'][1] = 'Here you can set a custom canonical URL like https://example.com/.';
+    $lang['canonicalKeepParams'][0] = 'Query parameters';
+    $lang['canonicalKeepParams'][1] = 'By default, Contao strips the query parameters in the canonical URL. Here you can add a comma-separated list of query parameters to preserve. Use &quot;*&quot; as a wildcard.';
+}

--- a/src/Tag/AbstractLinkTag.php
+++ b/src/Tag/AbstractLinkTag.php
@@ -1,13 +1,16 @@
 <?php
 
 /*
- * Copyright (c) 2020 Heimrich & Hannot GmbH
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
  *
  * @license LGPL-3.0-or-later
  */
 
 namespace HeimrichHannot\HeadBundle\Head;
 
+/**
+ * @deprecated Use HtmlHeadTagManager service instead
+ */
 abstract class AbstractLinkTag extends AbstractTag
 {
     /**

--- a/src/Tag/AbstractLinkTag.php
+++ b/src/Tag/AbstractLinkTag.php
@@ -8,6 +8,11 @@
 
 namespace HeimrichHannot\HeadBundle\Head;
 
+use Contao\System;
+use HeimrichHannot\HeadBundle\HeadTag\Link\CanonicalLink;
+use HeimrichHannot\HeadBundle\HeadTag\LinkTag;
+use HeimrichHannot\HeadBundle\Manager\HtmlHeadTagManager;
+
 /**
  * @deprecated Use HtmlHeadTagManager service instead
  */
@@ -26,6 +31,35 @@ abstract class AbstractLinkTag extends AbstractTag
      * @var string
      */
     protected static $key = 'rel';
+
+    public function setContent($content)
+    {
+        if (isset(static::$name)) {
+            if ('canonical' === static::$name) {
+                $tag = new CanonicalLink($content);
+            } else {
+                $tag = new LinkTag(static::$name, static::$name, $content);
+            }
+            System::getContainer()->get(HtmlHeadTagManager::class)->addLinkTag($tag);
+        } else {
+            parent::setContent($content);
+        }
+    }
+
+    public function getContent(): ?string
+    {
+        if (isset(static::$name)) {
+            $tag = System::getContainer()->get(HtmlHeadTagManager::class)->getLinkTag(static::$name);
+
+            if ($tag) {
+                return $tag->getAttributes()['href'];
+            }
+
+            return null;
+        }
+
+        return parent::getContent();
+    }
 
     /**
      * Generate the tag output.

--- a/src/Tag/AbstractTag.php
+++ b/src/Tag/AbstractTag.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (c) 2020 Heimrich & Hannot GmbH
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
  *
  * @license LGPL-3.0-or-later
  */
@@ -12,6 +12,9 @@ use Contao\Controller;
 use Contao\StringUtil;
 use HeimrichHannot\HeadBundle\Manager\TagManager;
 
+/**
+ * @deprecated Use HtmlHeadTagManager service instead
+ */
 abstract class AbstractTag implements TagInterface
 {
     /**

--- a/src/Tag/Link/LinkCanonical.php
+++ b/src/Tag/Link/LinkCanonical.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (c) 2020 Heimrich & Hannot GmbH
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
  *
  * @license LGPL-3.0-or-later
  */
@@ -10,6 +10,9 @@ namespace HeimrichHannot\HeadBundle\Tag\Link;
 
 use HeimrichHannot\HeadBundle\Head\AbstractLinkTag;
 
+/**
+ * @deprecated Use HtmlHeadTagManager service instead
+ */
 class LinkCanonical extends AbstractLinkTag
 {
     /**

--- a/src/Tag/Link/LinkNext.php
+++ b/src/Tag/Link/LinkNext.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (c) 2020 Heimrich & Hannot GmbH
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
  *
  * @license LGPL-3.0-or-later
  */
@@ -10,6 +10,9 @@ namespace HeimrichHannot\HeadBundle\Tag\Link;
 
 use HeimrichHannot\HeadBundle\Head\AbstractLinkTag;
 
+/**
+ * @deprecated Use HtmlHeadTagManager service instead
+ */
 class LinkNext extends AbstractLinkTag
 {
     /**

--- a/src/Tag/Link/LinkPrev.php
+++ b/src/Tag/Link/LinkPrev.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (c) 2020 Heimrich & Hannot GmbH
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
  *
  * @license LGPL-3.0-or-later
  */
@@ -10,6 +10,9 @@ namespace HeimrichHannot\HeadBundle\Tag\Link;
 
 use HeimrichHannot\HeadBundle\Head\AbstractLinkTag;
 
+/**
+ * @deprecated Use HtmlHeadTagManager service instead
+ */
 class LinkPrev extends AbstractLinkTag
 {
     /**

--- a/src/Tag/TagInterface.php
+++ b/src/Tag/TagInterface.php
@@ -1,13 +1,16 @@
 <?php
 
 /*
- * Copyright (c) 2020 Heimrich & Hannot GmbH
+ * Copyright (c) 2023 Heimrich & Hannot GmbH
  *
  * @license LGPL-3.0-or-later
  */
 
 namespace HeimrichHannot\HeadBundle\Head;
 
+/**
+ * @deprecated Use HtmlHeadTagManager service instead
+ */
 interface TagInterface
 {
     /**


### PR DESCRIPTION
- add link tag support
- use HtmlHeadTagManager for canonical urls, deprecated old tags
- cleanup and more deprecations
- support legacy way adding link tags
- port canonicals functionality from contao 4.13
